### PR TITLE
Fix issue where headers were not added to link interface for UCDD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,6 @@ find_package(xxHash 0.8.0 REQUIRED COMPONENTS xxhash PATHS ${LIBS_DIR}/xxHash)
 find_package(UUtils 1.1.1 REQUIRED PATHS ${LIBS_DIR}/UUtils)
 find_package(UDBM 2.0.11 REQUIRED PATHS ${LIBS_DIR}/UDBM)
 
-include_directories(
-    PRIVATE
-        # where the library itself will look for its internal headers
-        ${CMAKE_BINARY_DIR}/include
-    PUBLIC
-        # where top-level project will look for the library's public headers
-        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-        # where external projects will look for the library's public headers
-        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-)
-
 if(STATIC)
     # The project does not use neither threads nor networking, but
     # wsock32, ws2_32 and winpthread seem to be important for self-contained static binary

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,16 @@
 file(GLOB cdd_source "*.c" "*.cpp" "*.h")
 add_library(UCDD STATIC)
 
+target_include_directories(UCDD
+    PRIVATE
+        # where the library itself will look for its internal headers
+        ${CMAKE_BINARY_DIR}/include
+    PUBLIC
+        # where top-level project will look for the library's public headers
+        $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+        # where external projects will look for the library's public headers
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
 target_sources(UCDD PRIVATE ${cdd_source})
 target_link_libraries(UCDD UDBM)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,6 +10,7 @@ foreach(source ${test_sources})
     get_filename_component(test_target ${source} NAME_WE)
     add_executable(${test_target} ${source})
     target_link_libraries(${test_target} PRIVATE ${libs} doctest::doctest)
+    target_include_directories(${test_target} PRIVATE ${CMAKE_BINARY_DIR}/include)
     add_test(NAME ${test_target} COMMAND ${test_target})
     set_tests_properties(${test_target} PROPERTIES TIMEOUT 180) # "10": 102s on Linux32, 97s on Win32, 27s on Win64
 endforeach()


### PR DESCRIPTION
The issue is that the `PRIVATE` and `PUBLIC` keywords are only available for `target_include_directories` but not for `include_directories`. Which resulted in no headers being added to `UCDD`'s interface.

This should fix the linking error seen in
https://github.com/Ecdar/j-Ecdar/pull/96